### PR TITLE
Potential security issue in test_example.cpp: Missing pointer dereference in sizeof

### DIFF
--- a/test_example.cpp
+++ b/test_example.cpp
@@ -10,5 +10,5 @@ struct T1 {
 
 int main() {
     T1 t1, *pt1 = &t1;
-    memset(&t1, 0, sizeof(&t1)); // recommend: sizeof(struct T1)
+    memset(&t1, 0, sizeof(*t1)); // recommend: sizeof(struct T1)
 }


### PR DESCRIPTION
The operand to sizeof is the same as the pointer in a memory access. The developer likely intended to calculate the size of the object pointed to but forgot to dereference the pointer in the sizeof. The following code locations use the size of a pointer instead of the actual object's size:
---

1 instance of this defect were found in the following locations:
---
**Instance 1**
File : `test_example.cpp` 
Function: `memset` 
https://github.com/siva-msft/p-test/blob/f7a5d130d0108a9bd00f8407929fed3c2e366ec1/test_example.cpp#L14
Code extract:

```cpp
void foo() {
    T1 t1, *pt1 = &t1;
    memset(&t1, 0, sizeof(t1)); // correct usage
    memset(&t1, 0, sizeof(&t1)); // recommend: sizeof(struct T1) or sizeof(t1) <------ HERE
}

```

