### PR TITLE
Potential security issue in test_example.cpp: Missing pointer dereference in sizeof

### DIFF
--- a/test_example.cpp
+++ b/test_example.cpp
@@ -18,12 +18,12 @@ struct T1 {
 void ptr_1() {
     T1 t1, *pt1 = &t1;
     memset(&t1, 0, sizeof(t1)); // correct usage
-    memset(&t1, 0, sizeof(&t1)); // recommend: sizeof(struct T1) or sizeof(t1)
+    memset(&t1, 0, sizeof(*t1)); // recommend: sizeof(struct T1) or sizeof(t1)
 }
 
 void ptr_2() {
     T1 t1, *pt2 = &t1;
-    memcmp(&t1,pt2,sizeof(T1*)); // recommend: sizeof(struct T1)
+    memcmp(&t1,pt2,sizeof(*t1)); // recommend: sizeof(struct T1)
 }
 
 int main() {


### PR DESCRIPTION
The operand to sizeof is the same as the pointer in a memory access. The developer likely intended to calculate the size of the object pointed to but forgot to dereference the pointer in the sizeof. The following code locations use the size of a pointer instead of the actual object's size:
---

2 instances of this defect were found in the following locations:
---
**Instance 1**
File : `test_example.cpp` 
Function: `memset` 
https://github.com/siva-msft/p-test/blob/9bd5e19c65b0a9cbcde5b9cc91a3ec809e87d213/test_example.cpp#L21
Code extract:

```cpp
void ptr_1() {
    T1 t1, *pt1 = &t1;
    memset(&t1, 0, sizeof(t1)); // correct usage
    memset(&t1, 0, sizeof(&t1)); // recommend: sizeof(struct T1) or sizeof(t1) <------ HERE
}

```

---
**Instance 2**
File : `test_example.cpp` 
Function: `memcmp` 
https://github.com/siva-msft/p-test/blob/9bd5e19c65b0a9cbcde5b9cc91a3ec809e87d213/test_example.cpp#L26
Code extract:

```cpp

void ptr_2() {
    T1 t1, *pt2 = &t1;
    memcmp(&t1,pt2,sizeof(T1*)); // recommend: sizeof(struct T1) <------ HERE
}

```

