### PR TITLE
Potential security issue in example_ptr.cpp: Missing pointer dereference in sizeof

### DIFF
--- a/example_ptr.cpp
+++ b/example_ptr.cpp
@@ -27,23 +27,23 @@ int main() {
     // memset
     ////////////////////////////////////////////////////////////////////////////////////////////////
 // &var,sizeof(&var) -- popular fix was Remove & in sizeof but we can't see the & in the sizeof expr
-    memset(&t1, 0, sizeof(&t1)); // recommend: sizeof(struct T1)
+    memset(&t1, 0, sizeof(*t1)); // recommend: sizeof(struct T1)
     memset(t3.t3t2->t2a, 0, sizeof(t3.t3t2->t2a)); // recommend: sizeof(t3.t3t2->t2a); this is not a bug in the sample code
 // &var,sizeof(ptr-typedef)
-    memset(&t1, 0, sizeof(PT1)); // recommend: sizeof(struct T1)
+    memset(&t1, 0, sizeof(struct T1)); // recommend: sizeof(struct T1)
 // &var,sizeof(wrong-class)
     memset(&t1, 0, sizeof(T2));  // recommend: sizeof(t1)
 // &var,sizeof(wrong-var)
     memset(&t1, 0, sizeof(&t2));  // recommend: sizeof(t1)
 // var,sizeof(ptr-typedef)
-    memset(pt1, 0, sizeof(PT1)); // recommend: sizeof(struct T1)
+    memset(pt1, 0, sizeof(struct T1)); // recommend: sizeof(struct T1)
 // var,sizeof(var) - built-in type
     memset(b1, 0, sizeof(b1));   // recommend: N * sizeof(*b1) where N is the length of the array
     memset(b2, 0, sizeof(b2));   // recommend: N * sizeof(*b2) where N is the length of the array
 // var,sizeof(var) - not built-int type
-    memset(pt1, 0, sizeof(pt1)); // recommend: sizeof(*pt1)
+    memset(pt1, 0, sizeof(*pt1)); // recommend: sizeof(*pt1)
 // &var,sizeof(ptr-struct)
-    memset(&t1, 0, sizeof(struct T1*)); // recommend: sizeof(struct T1)
+    memset(&t1, 0, sizeof(*t1)); // recommend: sizeof(struct T1)
     ////////////////////////////////////////////////////////////////////////////////////////////////
     //alloc; var is the variable being assigned to instead of being an arg to the function
     ////////////////////////////////////////////////////////////////////////////////////////////////
@@ -57,19 +57,19 @@ int main() {
     //todo: memcmp; this has 2 ptr args
     ////////////////////////////////////////////////////////////////////////////////////////////////
 //&v1,&v1,sizeof(&v2) -- popular fix was Remove & in sizeof but we can't see the & in the sizeof expr
-    memcmp(&t1,&t2,sizeof(&t1));  // recommend: sizeof(struct T1)
+    memcmp(&t1,&t2,sizeof(*t1));  // recommend: sizeof(struct T1)
 //v1,v2,sizeof(v1)
-    memcmp(pt1,pt2,sizeof(pt1));  // recommend: sizeof(*pt1)
+    memcmp(pt1,pt2,sizeof(*pt1));  // recommend: sizeof(*pt1)
 //v1,v2,sizeof(v2)
-    memcmp(pt1,pt2,sizeof(pt2));  // recommend: sizeof(*pt2)
+    memcmp(pt1,pt2,sizeof(*pt1));  // recommend: sizeof(*pt2)
 //v1,v2,sizeof(ptr-typedef)
-    memcmp(pt1,pt2,sizeof(PT1));  // recommend: sizeof(struct T1)
+    memcmp(pt1,pt2,sizeof(struct T1));  // recommend: sizeof(struct T1)
 //&v1,v2,sizeof(v2)
-    memcmp(&t1,pt2,sizeof(pt2)); // recommend: sizeof(*pt2)
+    memcmp(&t1,pt2,sizeof(*t1)); // recommend: sizeof(*pt2)
 //&v1,&v2,sizeof(ptr-typdef)
-    memcmp(&t1,&t2,sizeof(PT1)); // recommend: sizeof(struct T1)
+    memcmp(&t1,&t2,sizeof(struct T1)); // recommend: sizeof(struct T1)
 //&v1,v2,sizeof(ptr-struct)
-    memcmp(&t1,pt2,sizeof(T1*)); // recommend: sizeof(struct T1)
+    memcmp(&t1,pt2,sizeof(*t1)); // recommend: sizeof(struct T1)
 //v1,&v2,sizeof(v1)
-    memcmp(pt1,&t2,sizeof(pt1)); // recommend: sizeof(*pt1)
+    memcmp(pt1,&t2,sizeof(*pt1)); // recommend: sizeof(*pt1)
 }


### PR DESCRIPTION
The operand to sizeof is the same as the pointer in a memory access. The developer likely intended to calculate the size of the object pointed to but forgot to dereference the pointer in the sizeof. The following code locations use the size of a pointer instead of the actual object's size:
---

15 instances of this defect were found in the following locations:
---
**Instance 1**
File : `example_ptr.cpp` 
Function: `memset` 
https://github.com/siva-msft/p-test/blob/9bd5e19c65b0a9cbcde5b9cc91a3ec809e87d213/example_ptr.cpp#L30
Code extract:

```cpp
    // memset
    ////////////////////////////////////////////////////////////////////////////////////////////////
// &var,sizeof(&var) -- popular fix was Remove & in sizeof but we can't see the & in the sizeof expr
    memset(&t1, 0, sizeof(&t1)); // recommend: sizeof(struct T1) <------ HERE
    memset(t3.t3t2->t2a, 0, sizeof(t3.t3t2->t2a)); // recommend: sizeof(t3.t3t2->t2a); this is not a bug in the sample code
// &var,sizeof(ptr-typedef)
```

---
**Instance 2**
File : `example_ptr.cpp` 
Function: `memset` 
https://github.com/siva-msft/p-test/blob/9bd5e19c65b0a9cbcde5b9cc91a3ec809e87d213/example_ptr.cpp#L33
Code extract:

```cpp
    memset(&t1, 0, sizeof(&t1)); // recommend: sizeof(struct T1)
    memset(t3.t3t2->t2a, 0, sizeof(t3.t3t2->t2a)); // recommend: sizeof(t3.t3t2->t2a); this is not a bug in the sample code
// &var,sizeof(ptr-typedef)
    memset(&t1, 0, sizeof(PT1)); // recommend: sizeof(struct T1) <------ HERE
// &var,sizeof(wrong-class)
    memset(&t1, 0, sizeof(T2));  // recommend: sizeof(t1)
```

---
**Instance 3**
File : `example_ptr.cpp` 
Function: `memset` 
https://github.com/siva-msft/p-test/blob/9bd5e19c65b0a9cbcde5b9cc91a3ec809e87d213/example_ptr.cpp#L39
Code extract:

```cpp
// &var,sizeof(wrong-var)
    memset(&t1, 0, sizeof(&t2));  // recommend: sizeof(t1)
// var,sizeof(ptr-typedef)
    memset(pt1, 0, sizeof(PT1)); // recommend: sizeof(struct T1) <------ HERE
// var,sizeof(var) - built-in type
    memset(b1, 0, sizeof(b1));   // recommend: N * sizeof(*b1) where N is the length of the array
```

---
**Instance 4**
File : `example_ptr.cpp` 
Function: `memset` 
https://github.com/siva-msft/p-test/blob/9bd5e19c65b0a9cbcde5b9cc91a3ec809e87d213/example_ptr.cpp#L41
Code extract:

```cpp
// var,sizeof(ptr-typedef)
    memset(pt1, 0, sizeof(PT1)); // recommend: sizeof(struct T1)
// var,sizeof(var) - built-in type
    memset(b1, 0, sizeof(b1));   // recommend: N * sizeof(*b1) where N is the length of the array <------ HERE
    memset(b2, 0, sizeof(b2));   // recommend: N * sizeof(*b2) where N is the length of the array
// var,sizeof(var) - not built-int type
```

---
**Instance 5**
File : `example_ptr.cpp` 
Function: `memset` 
https://github.com/siva-msft/p-test/blob/9bd5e19c65b0a9cbcde5b9cc91a3ec809e87d213/example_ptr.cpp#L42
Code extract:

```cpp
    memset(pt1, 0, sizeof(PT1)); // recommend: sizeof(struct T1)
// var,sizeof(var) - built-in type
    memset(b1, 0, sizeof(b1));   // recommend: N * sizeof(*b1) where N is the length of the array
    memset(b2, 0, sizeof(b2));   // recommend: N * sizeof(*b2) where N is the length of the array <------ HERE
// var,sizeof(var) - not built-int type
    memset(pt1, 0, sizeof(pt1)); // recommend: sizeof(*pt1)
```

---
**Instance 6**
File : `example_ptr.cpp` 
Function: `memset` 
https://github.com/siva-msft/p-test/blob/9bd5e19c65b0a9cbcde5b9cc91a3ec809e87d213/example_ptr.cpp#L44
Code extract:

```cpp
    memset(b1, 0, sizeof(b1));   // recommend: N * sizeof(*b1) where N is the length of the array
    memset(b2, 0, sizeof(b2));   // recommend: N * sizeof(*b2) where N is the length of the array
// var,sizeof(var) - not built-int type
    memset(pt1, 0, sizeof(pt1)); // recommend: sizeof(*pt1) <------ HERE
// &var,sizeof(ptr-struct)
    memset(&t1, 0, sizeof(struct T1*)); // recommend: sizeof(struct T1)
```

---
**Instance 7**
File : `example_ptr.cpp` 
Function: `memset` 
https://github.com/siva-msft/p-test/blob/9bd5e19c65b0a9cbcde5b9cc91a3ec809e87d213/example_ptr.cpp#L46
Code extract:

```cpp
// var,sizeof(var) - not built-int type
    memset(pt1, 0, sizeof(pt1)); // recommend: sizeof(*pt1)
// &var,sizeof(ptr-struct)
    memset(&t1, 0, sizeof(struct T1*)); // recommend: sizeof(struct T1) <------ HERE
    ////////////////////////////////////////////////////////////////////////////////////////////////
    //alloc; var is the variable being assigned to instead of being an arg to the function
```

---
**Instance 8**
File : `example_ptr.cpp` 
Function: `memcmp` 
https://github.com/siva-msft/p-test/blob/9bd5e19c65b0a9cbcde5b9cc91a3ec809e87d213/example_ptr.cpp#L60
Code extract:

```cpp
    //todo: memcmp; this has 2 ptr args
    ////////////////////////////////////////////////////////////////////////////////////////////////
//&v1,&v1,sizeof(&v2) -- popular fix was Remove & in sizeof but we can't see the & in the sizeof expr
    memcmp(&t1,&t2,sizeof(&t1));  // recommend: sizeof(struct T1) <------ HERE
//v1,v2,sizeof(v1)
    memcmp(pt1,pt2,sizeof(pt1));  // recommend: sizeof(*pt1)
```

---
**Instance 9**
File : `example_ptr.cpp` 
Function: `memcmp` 
https://github.com/siva-msft/p-test/blob/9bd5e19c65b0a9cbcde5b9cc91a3ec809e87d213/example_ptr.cpp#L62
Code extract:

```cpp
//&v1,&v1,sizeof(&v2) -- popular fix was Remove & in sizeof but we can't see the & in the sizeof expr
    memcmp(&t1,&t2,sizeof(&t1));  // recommend: sizeof(struct T1)
//v1,v2,sizeof(v1)
    memcmp(pt1,pt2,sizeof(pt1));  // recommend: sizeof(*pt1) <------ HERE
//v1,v2,sizeof(v2)
    memcmp(pt1,pt2,sizeof(pt2));  // recommend: sizeof(*pt2)
```

---
**Instance 10**
File : `example_ptr.cpp` 
Function: `memcmp` 
https://github.com/siva-msft/p-test/blob/9bd5e19c65b0a9cbcde5b9cc91a3ec809e87d213/example_ptr.cpp#L64
Code extract:

```cpp
//v1,v2,sizeof(v1)
    memcmp(pt1,pt2,sizeof(pt1));  // recommend: sizeof(*pt1)
//v1,v2,sizeof(v2)
    memcmp(pt1,pt2,sizeof(pt2));  // recommend: sizeof(*pt2) <------ HERE
//v1,v2,sizeof(ptr-typedef)
    memcmp(pt1,pt2,sizeof(PT1));  // recommend: sizeof(struct T1)
```

---
**Instance 11**
File : `example_ptr.cpp` 
Function: `memcmp` 
https://github.com/siva-msft/p-test/blob/9bd5e19c65b0a9cbcde5b9cc91a3ec809e87d213/example_ptr.cpp#L66
Code extract:

```cpp
//v1,v2,sizeof(v2)
    memcmp(pt1,pt2,sizeof(pt2));  // recommend: sizeof(*pt2)
//v1,v2,sizeof(ptr-typedef)
    memcmp(pt1,pt2,sizeof(PT1));  // recommend: sizeof(struct T1) <------ HERE
//&v1,v2,sizeof(v2)
    memcmp(&t1,pt2,sizeof(pt2)); // recommend: sizeof(*pt2)
```

---
**Instance 12**
File : `example_ptr.cpp` 
Function: `memcmp` 
https://github.com/siva-msft/p-test/blob/9bd5e19c65b0a9cbcde5b9cc91a3ec809e87d213/example_ptr.cpp#L68
Code extract:

```cpp
//v1,v2,sizeof(ptr-typedef)
    memcmp(pt1,pt2,sizeof(PT1));  // recommend: sizeof(struct T1)
//&v1,v2,sizeof(v2)
    memcmp(&t1,pt2,sizeof(pt2)); // recommend: sizeof(*pt2) <------ HERE
//&v1,&v2,sizeof(ptr-typdef)
    memcmp(&t1,&t2,sizeof(PT1)); // recommend: sizeof(struct T1)
```

---
**Instance 13**
File : `example_ptr.cpp` 
Function: `memcmp` 
https://github.com/siva-msft/p-test/blob/9bd5e19c65b0a9cbcde5b9cc91a3ec809e87d213/example_ptr.cpp#L70
Code extract:

```cpp
//&v1,v2,sizeof(v2)
    memcmp(&t1,pt2,sizeof(pt2)); // recommend: sizeof(*pt2)
//&v1,&v2,sizeof(ptr-typdef)
    memcmp(&t1,&t2,sizeof(PT1)); // recommend: sizeof(struct T1) <------ HERE
//&v1,v2,sizeof(ptr-struct)
    memcmp(&t1,pt2,sizeof(T1*)); // recommend: sizeof(struct T1)
```

---
**Instance 14**
File : `example_ptr.cpp` 
Function: `memcmp` 
https://github.com/siva-msft/p-test/blob/9bd5e19c65b0a9cbcde5b9cc91a3ec809e87d213/example_ptr.cpp#L72
Code extract:

```cpp
//&v1,&v2,sizeof(ptr-typdef)
    memcmp(&t1,&t2,sizeof(PT1)); // recommend: sizeof(struct T1)
//&v1,v2,sizeof(ptr-struct)
    memcmp(&t1,pt2,sizeof(T1*)); // recommend: sizeof(struct T1) <------ HERE
//v1,&v2,sizeof(v1)
    memcmp(pt1,&t2,sizeof(pt1)); // recommend: sizeof(*pt1)
```

---
**Instance 15**
File : `example_ptr.cpp` 
Function: `memcmp` 
https://github.com/siva-msft/p-test/blob/9bd5e19c65b0a9cbcde5b9cc91a3ec809e87d213/example_ptr.cpp#L74
Code extract:

```cpp
//&v1,v2,sizeof(ptr-struct)
    memcmp(&t1,pt2,sizeof(T1*)); // recommend: sizeof(struct T1)
//v1,&v2,sizeof(v1)
    memcmp(pt1,&t2,sizeof(pt1)); // recommend: sizeof(*pt1) <------ HERE
}

```

